### PR TITLE
[wording] don't use 'local storage' in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Lead Maintainer: [Jeffrey White](https://github.com/OmniJeff)
 
 The ***yar*** [hapi](https://github.com/hapijs/hapi) plugin adds session support - a persistant state across multiple browser
 requests using an [iron](https://github.com/hueniverse/iron) encrypted cookie and server-side storage. **yar** tries to fit
-session data into a session cookie based  on a configured maximum size. If the content is too big to fit, it uses local storage
-via the hapi plugin cache interface.
+session data into a session cookie based  on a configured maximum size. If the content is too big to fit, it uses server storage
+via the [hapi plugin cache](http://hapijs.com/api#servercacheoptions) interface.
 
 For example, the first handler sets a session key and the second gets it:
 ```javascript


### PR DESCRIPTION
Hi,
I find it confusing to use the word 'local storage', as it can be confused with browser side LocalStorage API.
